### PR TITLE
Update turtlebot status 

### DIFF
--- a/src/isar_turtlebot/models/turtlebot_status.py
+++ b/src/isar_turtlebot/models/turtlebot_status.py
@@ -22,7 +22,7 @@ class TurtlebotStatus(str, Enum):
     def map_to_turtlebot_status(cls, status_code: int) -> "TurtlebotStatus":
         if status_code == 1:
             return TurtlebotStatus.Active
-        elif status_code == 2:
+        elif status_code == 2 or status_code == 4:
             return TurtlebotStatus.Failure
         elif status_code == 3:
             return TurtlebotStatus.Succeeded


### PR DESCRIPTION
Include status code 4 to `TurtlebotStatus.Failure` to prevent ISAR from breaking when occuring. One example where this applies is when the Turtlebot move_base command fails after running the unstuck procedure. It is currently used to simulate failed DriveTo steps to test task-dependencies in ISAR. 