### PR TITLE
Add empty models folder to resolve build error

### DIFF
--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
`docker compose build` would fail if there was no models folder available. 