### PR TITLE
Bug - DriveTo causes crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The robot can be located with `2DPose Estimate` and naviagted with `2D Navigatio
 Download and install [ISAR](github.com/equinor/isar) on your computer. Follow the [robot integration guide](https://github.com/equinor/isar#robot-integration) installing `isar-turtlebot`. Remember to set the robot directory environment variable:
 
 ```bash
-export ROBOT_PACKAGE=isar_turtlebot
+export ISAR_ROBOT_PACKAGE=isar_turtlebot
 ```
 
 For the ISAR API to communicate with the simulator, you will need rosbridge:

--- a/src/isar_turtlebot/turtlebot/taskhandlers/driveto.py
+++ b/src/isar_turtlebot/turtlebot/taskhandlers/driveto.py
@@ -2,15 +2,14 @@ import time
 from typing import Optional
 
 from isar.services.coordinates.transformation import Transformation
-from robot_interface.models.geometry.frame import Frame
-from robot_interface.models.geometry.pose import Pose
-from robot_interface.models.mission.task import DriveToPose
-
 from isar_turtlebot.models.turtlebot_status import Status
 from isar_turtlebot.ros_bridge.ros_bridge import RosBridge
 from isar_turtlebot.settings import settings
 from isar_turtlebot.turtlebot.taskhandlers.taskhandler import TaskHandler
 from isar_turtlebot.utilities.pose_message import encode_pose_message
+from robot_interface.models.geometry.frame import Frame
+from robot_interface.models.geometry.pose import Pose
+from robot_interface.models.mission.task import DriveToPose
 
 
 class DriveToHandler(TaskHandler):
@@ -42,9 +41,11 @@ class DriveToHandler(TaskHandler):
                 raise TimeoutError("Publishing navigation message timed out")
 
     def _goal_id(self) -> Optional[str]:
-        goal_id: str = self.goal_id_from_message(
-            message=self.bridge.task_status.get_value()
-        )
+        message = self.bridge.task_status.get_value()
+        if not message:
+            return None
+
+        goal_id: str = self.goal_id_from_message(message=message)
         return goal_id
 
     def get_status(self) -> Status:

--- a/src/isar_turtlebot/turtlebot/turtlebot.py
+++ b/src/isar_turtlebot/turtlebot/turtlebot.py
@@ -5,11 +5,6 @@ from typing import Optional, Sequence
 from uuid import UUID
 
 from isar.services.coordinates.transformation import Transformation
-from robot_interface.models.exceptions import RobotException
-from robot_interface.models.inspection.inspection import Inspection
-from robot_interface.models.mission.status import TaskStatus
-from robot_interface.models.mission.task import InspectionTask, Task
-
 from isar_turtlebot.models.turtlebot_status import Status
 from isar_turtlebot.ros_bridge import RosBridge
 from isar_turtlebot.turtlebot.taskhandlers import (
@@ -18,6 +13,13 @@ from isar_turtlebot.turtlebot.taskhandlers import (
     TakeThermalImageHandler,
 )
 from isar_turtlebot.turtlebot.taskhandlers.taskhandler import TaskHandler
+from robot_interface.models.exceptions import (
+    RobotCommunicationException,
+    RobotException,
+)
+from robot_interface.models.inspection.inspection import Inspection
+from robot_interface.models.mission.status import TaskStatus
+from robot_interface.models.mission.task import InspectionTask, Task
 
 
 class Turtlebot:


### PR DESCRIPTION
Sending a drive-to command from isar caused a crash when the id was null.
Also, the exception "RobotCommunicationException" caused a crash when it was raised because it was not imported.