### PR TITLE
Run headless by default

### DIFF
--- a/docker-compose-nvidia.yml
+++ b/docker-compose-nvidia.yml
@@ -2,3 +2,8 @@ version: "2.3"
 services:
   noetic:
     runtime: nvidia
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    environment:
+      - DISPLAY=${DISPLAY}
+      - HEADLESS=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,10 @@ services:
       - "9090:9090"
       - "5000:5000"
     environment:
-      - DISPLAY=${DISPLAY}
       - TELEOP_CONTROLLER=${TELEOP_CONTROLLER:-disabled}
       - ENABLE_MANIPULATOR=${ENABLE_MANIPULATOR:-false}
       - MANIPULATOR_GUI=${MANIPULATOR_GUI:-disabled}
-      - HEADLESS=${HEADLESS:-false}
-    volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix
+      - HEADLESS=${HEADLESS:-true}
     tty: true
     networks:
       - turtlenet


### PR DESCRIPTION
The simulator now runs headless as default with additional added
parameters in a settings file to run with GUI.