### PR TITLE
Update docker compose from docker-compose, update how gpu is requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If the result is `snap.docker.dockerd.service`, the installation has been done u
 Build the container. This needs to be done once before one can give the container access to the screen.
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 Give the docker container access to the screen, this needs to be done each time the computer is restarted.
@@ -48,13 +48,13 @@ xhost +local:`docker inspect --format='{{ .Config.Hostname }}' turtle_sim`
 Start the simulation
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 To build and start the simulation
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 The simulation world that is used can be set by changing the world variable in the 'entrypoint.sh' file.
@@ -62,13 +62,13 @@ The simulation world that is used can be set by changing the world variable in t
 Additional settings, such as using Nvidia GPU or gamepad input to the docker container is included via separate .yml-files. To run the docker container with these settings the corresponding `docker-compose-setting.yml` file must be specified together with the main `docker-compose.yml` file. Several setting files can be included.
 
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose-setting.yml up --build
+docker compose -f docker-compose.yml -f docker-compose-setting.yml up --build
 ```
 
-To run the simulation in headless mode set the environment variable `HEADLESS=true` prior to launching the docker container. Alternatively directly as an environment variable in the docker-compose command:
+To run the simulation in headless mode set the environment variable `HEADLESS=true` prior to launching the docker container. Alternatively directly as an environment variable in the docker compose command:
 
 ```bash
-HEADLESS=true docker-compose up --build
+HEADLESS=true docker compose up --build
 ```
 
 The simulation can then be viewed at webviz with the following link: https://webviz.io/app/?rosbridge-websocket-url=ws://localhost:9090/
@@ -105,7 +105,7 @@ Then run the following:
 To run the simulation with the custom model set the WORLD_NAME as an environment variable in a .env file or argument like this:
 
 ```bash
-WORLD_NAME=your_custom_model docker-compose up --build
+WORLD_NAME=your_custom_model docker compose up --build
 ```
 ## Simulation without docker
 
@@ -231,7 +231,7 @@ jstest /dev/input/jsX.
 To enable teleoperation with a joystick while running in docker the joystick must be added as a device in `docker-compose.yaml`. This is done by including the `docker-compose-gamepad.yaml` file as decribed in the docker section. Additionally the environment variable `TELEOP_CONTROLLER` must be specified(currently `"xbox"` is the only supported controller):
 
 ```bash
-TELEOP_CONTROLLER="xbox" docker-compose -f docker-compose.yml -f docker-compose-gamepad.yml up --build
+TELEOP_CONTROLLER="xbox" docker compose -f docker-compose.yml -f docker-compose-gamepad.yml up --build
 ```
 
 To enable teleoperation while running locally, first install the two packages:
@@ -274,7 +274,7 @@ roslaunch isar-turtlebot turtlebot_manipulator.launch open_manipulator_gui:=true
 Alternatively the simulation with manipulator can also run in docker by including the parameter `ENABLE_MANIPULATOR` and the controller GUI set according to the description above:
 
 ```bash
-sudo ENABLE_MANIPULATOR=true MANIPULATOR_GUI="rviz" docker-compose up --build
+sudo ENABLE_MANIPULATOR=true MANIPULATOR_GUI="rviz" docker compose up --build
 ```
 
 The simulation can also run in docker as described in the section for [docker](#run-simulation).
@@ -291,7 +291,7 @@ roslaunch isar_turtlebot turtlebot_manipulator.launch teleop_controller:="xbox"
 To run simulation in docker with teleoperation of manipulator:
 
 ```bash
-sudo ENABLE_MANIPULATOR=true MANIPULATOR_GUI="rviz" TELEOP_CONTROLLER="xbox" docker-compose -f docker-compose.yml -f docker-compose-setting.yml  up --build
+sudo ENABLE_MANIPULATOR=true MANIPULATOR_GUI="rviz" TELEOP_CONTROLLER="xbox" docker compose -f docker-compose.yml -f docker-compose-setting.yml  up --build
 
 ```
 

--- a/docker-compose-nvidia.yml
+++ b/docker-compose-nvidia.yml
@@ -1,9 +1,15 @@
-version: "2.3"
+version: "3.9"
 services:
   noetic:
-    runtime: nvidia
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
     environment:
       - DISPLAY=${DISPLAY}
       - HEADLESS=false
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/src/isar_turtlebot/services/video_streamer.py
+++ b/src/isar_turtlebot/services/video_streamer.py
@@ -10,7 +10,6 @@ class VideoStreamer:
         self.bridge: RosBridge = bridge
 
     def main(self):
-
         while True:
             image_data: str = self.bridge.video_stream.get_image()
             image_bytes: bytes = base64.b64decode(image_data)

--- a/src/isar_turtlebot/turtlebot/step_handlers/driveto.py
+++ b/src/isar_turtlebot/turtlebot/step_handlers/driveto.py
@@ -26,7 +26,6 @@ class DriveToHandler(StepHandler):
         self,
         step: DriveToPose,
     ) -> None:
-
         goal_pose: Pose = self.transform.transform_pose(
             pose=step.pose, from_=step.pose.frame, to_=Frame("robot")
         )

--- a/src/isar_turtlebot/turtlebot/step_handlers/takeimage.py
+++ b/src/isar_turtlebot/turtlebot/step_handlers/takeimage.py
@@ -47,7 +47,6 @@ class TakeImageHandler(StepHandler):
         self.inspection: Optional[Image] = None
 
     def start(self, step: TakeImage) -> None:
-
         self.status = Status.Active
 
         current_pose: Pose = self._get_robot_pose()

--- a/src/isar_turtlebot/turtlebot/step_handlers/takethermalimage.py
+++ b/src/isar_turtlebot/turtlebot/step_handlers/takethermalimage.py
@@ -53,7 +53,6 @@ class TakeThermalImageHandler(StepHandler):
         self,
         step: TakeThermalImage,
     ) -> None:
-
         self.status = Status.Active
         current_pose: Pose = self._get_robot_pose()
         target: Position = self.transform.transform_position(

--- a/src/isar_turtlebot/turtlebot/turtlebot.py
+++ b/src/isar_turtlebot/turtlebot/turtlebot.py
@@ -40,7 +40,6 @@ class Turtlebot:
     """Step manager for Turtlebot."""
 
     def __init__(self, bridge: RosBridge, transform: Transform) -> None:
-
         self.logger: Logger = logging.getLogger("robot")
         self.bridge: RosBridge = bridge
         self.transform: Transform = transform

--- a/src/isar_turtlebot/utilities/inspection_pose.py
+++ b/src/isar_turtlebot/utilities/inspection_pose.py
@@ -4,7 +4,6 @@ from scipy.spatial.transform import Rotation
 
 
 def get_inspection_pose(current_pose: Pose, target: Position) -> Pose:
-
     direction = target.to_array() - current_pose.position.to_array()
     alpha = np.arctan2(direction[1], direction[0])
     rotation = Rotation.from_euler("zyx", [alpha, 0, 0], degrees=False)


### PR DESCRIPTION
Docker has integrated `docker-compose` as a command under `docker`, ie `docker compose --help`.
Docker has added an improved way of requesting capabilities like gpu. Ye olde days of `runtime: nvidia` has finally passed.

Examples:
```sh
# When using a dockerfile then request gpu directly via argument `--gpus=<ID | "all">`
docker run -it --rm --gpus=all cuda-test
```
```yaml
# When using docker compose then request capabilities under the `deploy` tag
demo:
   build: something
   command: something
   deploy:
      resources:
         reservations:
            devices:
               - capabilities: [gpu]
```
This is the way.

---

(Not added to pull request, just a suggestion)

Finally, if you want to simplify start/stop of container(s) along with clean up of permissions, then consider using a shell script like this:

```sh
#!/bin/bash

#######################################################################################
### PURPOSE
###

# Let the user do the following with one simple command:
# 1. Build container
# 2. Get container running in a detached from the shell
# 3. Provide the container access to X11 on the host
# 4. Enter the container
# 5. ...And now the user can start playing around with the app :)

# After exiting the container...
# 6. Remove the container access to X11 on the host
# 7. Stop and remove container

docker compose up --build --detach
xhost +local:$(docker inspect --format='{{ .Config.Hostname }}' turtle_sim)
docker exec -it turtle_sim bash

xhost -local:$(docker inspect --format='{{ .Config.Hostname }}' turtle_sim)
docker compose down --volumes
```