### PR TITLE
Add a default robot status function for the sim

### DIFF
--- a/src/isar_turtlebot/robotinterface.py
+++ b/src/isar_turtlebot/robotinterface.py
@@ -8,6 +8,7 @@ from alitra import MapAlignment, Transform, align_maps
 from robot_interface.models.initialize import InitializeParams
 from robot_interface.models.inspection.inspection import Inspection
 from robot_interface.models.mission import InspectionStep, Step, StepStatus
+from robot_interface.models.mission.status import RobotStatus
 from robot_interface.robot_interface import RobotInterface
 from robot_interface.telemetry.mqtt_client import MqttTelemetryPublisher
 
@@ -80,3 +81,6 @@ class Robot(RobotInterface):
         publisher_threads.append(battery_thread)
 
         return publisher_threads
+
+    def robot_status(self) -> RobotStatus:
+        return RobotStatus.Available

--- a/src/isar_turtlebot/services/video_streamer.py
+++ b/src/isar_turtlebot/services/video_streamer.py
@@ -1,7 +1,5 @@
 import base64
 
-import cv2
-
 from isar_turtlebot.ros_bridge.ros_bridge import RosBridge
 
 
@@ -10,7 +8,6 @@ class VideoStreamer:
         self.bridge: RosBridge = bridge
 
     def main(self):
-
         while True:
             image_data: str = self.bridge.video_stream.get_image()
             image_bytes: bytes = base64.b64decode(image_data)

--- a/src/isar_turtlebot/turtlebot/step_handlers/driveto.py
+++ b/src/isar_turtlebot/turtlebot/step_handlers/driveto.py
@@ -26,7 +26,6 @@ class DriveToHandler(StepHandler):
         self,
         step: DriveToPose,
     ) -> None:
-
         goal_pose: Pose = self.transform.transform_pose(
             pose=step.pose, from_=step.pose.frame, to_=Frame("robot")
         )

--- a/src/isar_turtlebot/turtlebot/step_handlers/takeimage.py
+++ b/src/isar_turtlebot/turtlebot/step_handlers/takeimage.py
@@ -47,7 +47,6 @@ class TakeImageHandler(StepHandler):
         self.inspection: Optional[Image] = None
 
     def start(self, step: TakeImage) -> None:
-
         self.status = Status.Active
 
         current_pose: Pose = self._get_robot_pose()

--- a/src/isar_turtlebot/turtlebot/step_handlers/takethermalimage.py
+++ b/src/isar_turtlebot/turtlebot/step_handlers/takethermalimage.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Optional
 from uuid import uuid4
 
-import numpy as np
 import PIL.Image as PILImage
+import numpy as np
 from alitra import Pose, Position, Transform
 from robot_interface.models.inspection.inspection import (
     ThermalImage,
@@ -53,7 +53,6 @@ class TakeThermalImageHandler(StepHandler):
         self,
         step: TakeThermalImage,
     ) -> None:
-
         self.status = Status.Active
         current_pose: Pose = self._get_robot_pose()
         target: Position = self.transform.transform_position(

--- a/src/isar_turtlebot/turtlebot/turtlebot.py
+++ b/src/isar_turtlebot/turtlebot/turtlebot.py
@@ -40,7 +40,6 @@ class Turtlebot:
     """Step manager for Turtlebot."""
 
     def __init__(self, bridge: RosBridge, transform: Transform) -> None:
-
         self.logger: Logger = logging.getLogger("robot")
         self.bridge: RosBridge = bridge
         self.transform: Transform = transform

--- a/src/isar_turtlebot/utilities/inspection_pose.py
+++ b/src/isar_turtlebot/utilities/inspection_pose.py
@@ -4,7 +4,6 @@ from scipy.spatial.transform import Rotation
 
 
 def get_inspection_pose(current_pose: Pose, target: Position) -> Pose:
-
     direction = target.to_array() - current_pose.position.to_array()
     alpha = np.arctan2(direction[1], direction[0])
     rotation = Rotation.from_euler("zyx", [alpha, 0, 0], degrees=False)


### PR DESCRIPTION
This is a temporary solution that means the package works as before. A more sophisticated solution which actually indicates whether the robot is busy or offline should be implemented. 